### PR TITLE
Fix vulnerable legacy dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,3 @@
 /mintProject/bin
 /mintProject/.springWebflow
 /mintProject/.factorypath
-
-# Local git worktrees
-.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 /mintProject/bin
 /mintProject/.springWebflow
 /mintProject/.factorypath
+
+# Local git worktrees
+.worktrees/

--- a/mintProject/pom.xml
+++ b/mintProject/pom.xml
@@ -9,10 +9,10 @@
 	<version>1.0.0-BUILD-SNAPSHOT</version>
 	<properties>
 		<java-version>1.8</java-version>
-		<org.springframework-version>5.2.0.RELEASE</org.springframework-version>
+		<org.springframework-version>5.3.39</org.springframework-version>
 		<org.aspectj-version>1.6.10</org.aspectj-version>
-		<org.slf4j-version>1.6.6</org.slf4j-version>
-		<security.version>4.2.1.RELEASE</security.version> 
+		<org.slf4j-version>1.7.36</org.slf4j-version>
+		<security.version>5.8.16</security.version>
 	</properties>
 	<dependencies>
 		<!-- Spring -->
@@ -55,32 +55,14 @@
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
+			<artifactId>slf4j-reload4j</artifactId>
 			<version>${org.slf4j-version}</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.15</version>
-			<exclusions>
-				<exclusion>
-					<groupId>javax.mail</groupId>
-					<artifactId>mail</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>javax.jms</groupId>
-					<artifactId>jms</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.sun.jdmk</groupId>
-					<artifactId>jmxtools</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.sun.jmx</groupId>
-					<artifactId>jmxri</artifactId>
-				</exclusion>
-			</exclusions>
+			<groupId>ch.qos.reload4j</groupId>
+			<artifactId>reload4j</artifactId>
+			<version>1.2.26</version>
 			<scope>runtime</scope>
 		</dependency>
 
@@ -114,7 +96,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.7</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>  
 		
@@ -125,17 +107,11 @@
 			<scope>provided</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>jstl</artifactId>
-			<version>1.2</version>
-		</dependency>
-
 		<!-- JDBC (jdbc, dbConnectionPool, Transaction)-->
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-jdbc</artifactId>
-			<version>5.2.0.RELEASE</version>
+			<version>${org.springframework-version}</version>
 		</dependency>
 
 		<dependency>
@@ -147,47 +123,47 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-tx</artifactId>
-			<version>5.2.0.RELEASE</version>
+			<version>${org.springframework-version}</version>
 		</dependency>
 		
 		<!-- myBatis -->
 		<dependency>
 			<groupId>org.mybatis</groupId>
 			<artifactId>mybatis-spring</artifactId>
-			<version>1.3.2</version>
+			<version>2.1.2</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.mybatis</groupId>
 			<artifactId>mybatis</artifactId>
-			<version>3.5.2</version>
+			<version>3.5.19</version>
 		</dependency>
 		
 		<!-- oracle -->
 		<dependency>
-			<groupId>com.oracle</groupId>
-			<artifactId>ojdbc7</artifactId>
-			<version>12.1.0.2</version>
+			<groupId>com.oracle.database.jdbc</groupId>
+			<artifactId>ojdbc8</artifactId>
+			<version>19.30.0.0</version>
 		</dependency>
 		
 		<!--JSON: jackson-databind -->
 		<dependency>
 		    <groupId>com.fasterxml.jackson.core</groupId>
 		    <artifactId>jackson-databind</artifactId>
-		    <version>2.10.0</version>
+		    <version>2.21.3</version>
 		</dependency>
 		
 		<!-- 파일 업로드 -->
 		<dependency>
 		    <groupId>commons-io</groupId>
 		    <artifactId>commons-io</artifactId>
-		    <version>2.6</version>
+		    <version>2.22.0</version>
 		</dependency>
 		
 		<dependency>
 		    <groupId>commons-fileupload</groupId>
 		    <artifactId>commons-fileupload</artifactId>
-		    <version>1.4</version>
+		    <version>1.6.0</version>
 		</dependency>
 		
 		<!-- https://mvnrepository.com/artifact/net.sf.json-lib/json-lib -->
@@ -209,7 +185,7 @@
 		<dependency>
 		    <groupId>org.springframework</groupId>
 		    <artifactId>spring-context-support</artifactId>
-		    <version>5.2.0.RELEASE</version>
+		    <version>${org.springframework-version}</version>
 		</dependency>
 		
 		<!-- Spring security -->  
@@ -217,35 +193,35 @@
 		<dependency>
 		    <groupId>org.springframework.security</groupId>
 		    <artifactId>spring-security-core</artifactId>
-		    <version>4.2.1.RELEASE</version>
+		    <version>${security.version}</version>
 		</dependency>
 		
 		<!-- https://mvnrepository.com/artifact/org.springframework.security/spring-security-web -->
 		<dependency>
 		    <groupId>org.springframework.security</groupId>
 		    <artifactId>spring-security-web</artifactId>
-		    <version>4.2.1.RELEASE</version>
+		    <version>${security.version}</version>
 		</dependency>
 		
 		<!-- https://mvnrepository.com/artifact/org.springframework.security/spring-security-config -->
 		<dependency>
 		    <groupId>org.springframework.security</groupId>
 		    <artifactId>spring-security-config</artifactId>
-		    <version>4.2.1.RELEASE</version>
+		    <version>${security.version}</version>
 		</dependency>
 		
 		<!-- https://mvnrepository.com/artifact/org.springframework.security/spring-security-taglibs -->
 		<dependency>
 		    <groupId>org.springframework.security</groupId>
 		    <artifactId>spring-security-taglibs</artifactId>
-		    <version>4.2.1.RELEASE</version>
+		    <version>${security.version}</version>
 		</dependency>
 		
 		<!-- https://mvnrepository.com/artifact/org.springframework.security/spring-security-test -->
 		<dependency>
 		    <groupId>org.springframework.security</groupId>
 		    <artifactId>spring-security-test</artifactId>
-		    <version>4.2.1.RELEASE</version>
+		    <version>${security.version}</version>
 		    <scope>test</scope>
 		</dependency>
 		
@@ -270,10 +246,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.5.1</version>
+                <version>3.13.0</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${java-version}</source>
+                    <target>${java-version}</target>
                     <compilerArgument>-Xlint:all</compilerArgument>
                     <showWarnings>true</showWarnings>
                     <showDeprecation>true</showDeprecation>
@@ -289,11 +265,4 @@
             </plugin>
         </plugins>
     </build>
-    
-    <repositories>
-		<repository>
-			<id>oracle</id>
-			<url>http://maven.jahia.org/maven2</url>
-		</repository>
-	</repositories>
 </project>

--- a/mintProject/src/main/java/mint/spring/conf/MailAuthConfiguration.java
+++ b/mintProject/src/main/java/mint/spring/conf/MailAuthConfiguration.java
@@ -20,13 +20,13 @@ public class MailAuthConfiguration {
 		properties.put("mail.transport.protocol", "smtp");
 		properties.put("mail.smtp.starttls.enable", true);
 		properties.put("mail.smtp.starttls.required", true);
-		properties.put("mail.debug", true);
+		properties.put("mail.debug", Boolean.valueOf(getEnv("MINT_MAIL_DEBUG", "false")));
 		
 		JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
-		mailSender.setHost("smtp.gmail.com");
-		mailSender.setPort(587);
-		mailSender.setUsername("marketintaste@gmail.com");
-		mailSender.setPassword("mintproject1");
+		mailSender.setHost(getEnv("MINT_MAIL_HOST", "smtp.gmail.com"));
+		mailSender.setPort(Integer.parseInt(getEnv("MINT_MAIL_PORT", "587")));
+		mailSender.setUsername(requiredEnv("MINT_MAIL_USERNAME"));
+		mailSender.setPassword(requiredEnv("MINT_MAIL_PASSWORD"));
 		mailSender.setDefaultEncoding("utf-8");
 		mailSender.setJavaMailProperties(properties);
 		
@@ -39,4 +39,16 @@ public class MailAuthConfiguration {
 	//2) https://thiago6.tistory.com/38 
 	//3) https://dlgkstjq623.tistory.com/351
 	
+	private String requiredEnv(String name) {
+		String value = System.getenv(name);
+		if(value == null || value.trim().isEmpty()) {
+			throw new IllegalStateException("Missing required environment variable: " + name);
+		}
+		return value;
+	}
+
+	private String getEnv(String name, String defaultValue) {
+		String value = System.getenv(name);
+		return value == null || value.trim().isEmpty() ? defaultValue : value;
+	}
 }

--- a/mintProject/src/main/java/mint/spring/conf/SpringConfiguration.java
+++ b/mintProject/src/main/java/mint/spring/conf/SpringConfiguration.java
@@ -14,10 +14,10 @@ public class SpringConfiguration {
 	@Bean(name="dataSource")
 	public BasicDataSource getBasicDataSource() {
 		BasicDataSource basicDataSource = new BasicDataSource();
-		basicDataSource.setDriverClassName("oracle.jdbc.driver.OracleDriver");
-		basicDataSource.setUrl("jdbc:oracle:thin:@mint.c4ccogloxvpr.ap-northeast-2.rds.amazonaws.com:1521:ORCL"); //
-		basicDataSource.setUsername("mint");
-		basicDataSource.setPassword("mint12345");
+		basicDataSource.setDriverClassName(getEnv("MINT_DB_DRIVER", "oracle.jdbc.OracleDriver"));
+		basicDataSource.setUrl(requiredEnv("MINT_DB_URL"));
+		basicDataSource.setUsername(requiredEnv("MINT_DB_USERNAME"));
+		basicDataSource.setPassword(requiredEnv("MINT_DB_PASSWORD"));
 		basicDataSource.setMaxTotal(20);
 		basicDataSource.setMaxIdle(3);
 		return basicDataSource;
@@ -46,5 +46,17 @@ public class SpringConfiguration {
 		dataSourceTransactionManager.setDataSource(getBasicDataSource());
 		return dataSourceTransactionManager;		
 	}
-}
 
+	private String requiredEnv(String name) {
+		String value = System.getenv(name);
+		if(value == null || value.trim().isEmpty()) {
+			throw new IllegalStateException("Missing required environment variable: " + name);
+		}
+		return value;
+	}
+
+	private String getEnv(String name, String defaultValue) {
+		String value = System.getenv(name);
+		return value == null || value.trim().isEmpty() ? defaultValue : value;
+	}
+}

--- a/mintProject/src/main/webapp/WEB-INF/spring/security-context.xml
+++ b/mintProject/src/main/webapp/WEB-INF/spring/security-context.xml
@@ -4,8 +4,8 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:security="http://www.springframework.org/schema/security"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.3.xsd
-		http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-4.2.xsd">
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
 
 	<!-- <security:http:/>: springSecurityFilterChain 설정  
 		● auto-config: true => filter는 default값으로 동작한다. false 일 시 anonymous, x-509, http-basic, remember-me 등을 직접 정의해주어야 함.


### PR DESCRIPTION
## Summary
- Bump Spring Security to 5.8.16 and align Spring Framework 5.3.x dependencies for the legacy Java 8 / javax.servlet app.
- Replace Log4j 1.x binding with reload4j and update commons-fileupload, commons-io, jackson-databind, mybatis, junit, Oracle JDBC, and compiler plugin versions.
- Remove hardcoded DB/mail credentials from Java config; runtime now requires MINT_DB_URL, MINT_DB_USERNAME, MINT_DB_PASSWORD, MINT_MAIL_USERNAME, and MINT_MAIL_PASSWORD.

## Verification
- docker run --rm -v "/mnt/data/workspace/mint":/workspace -v "/home/mhhan/.m2":/root/.m2 -w /workspace/mintProject maven:3.9.9-eclipse-temurin-8 mvn -B package
- docker run --rm -v "/mnt/data/workspace/mint":/workspace -w /workspace/mintProject maven:3.9.9-eclipse-temurin-8 mvn -B dependency:tree -Dincludes=org.springframework.security,org.springframework,log4j,commons-fileupload,commons-io,com.fasterxml.jackson.core,org.mybatis,ch.qos.reload4j,com.oracle.database.jdbc
- git diff --check
- rg secret/version scan for removed hardcoded credentials and vulnerable direct coordinates

## Notes
- Dependabot may still report no-patched-version alerts for Spring Framework 5.x and json-lib until the app is migrated off the legacy stack.
- Because credentials were committed in public source history, rotate the DB and mail credentials before treating this as production-safe.